### PR TITLE
Make the orientation of triangle() clockwise

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1046,12 +1046,12 @@ p5.RendererGL.prototype.triangle = function(args) {
     const _triangle = function() {
       const vertices = [];
       vertices.push(new p5.Vector(0, 0, 0));
-      vertices.push(new p5.Vector(0, 1, 0));
       vertices.push(new p5.Vector(1, 0, 0));
+      vertices.push(new p5.Vector(0, 1, 0));
       this.strokeIndices = [[0, 1], [1, 2], [2, 0]];
       this.vertices = vertices;
       this.faces = [[0, 1, 2]];
-      this.uvs = [0, 0, 0, 1, 1, 1];
+      this.uvs = [0, 0, 1, 0, 1, 1];
     };
     const triGeom = new p5.Geometry(1, 1, _triangle);
     triGeom._makeTriangleEdges()._edgesToVertices();


### PR DESCRIPTION
The order of vertices in the triangle function is counterclockwise, unlike most other primitives.
For this reason, the direction of the normal line will be opposite to when creating a triangle by specifying the same order in immediate mode.
So I fixed it. Along with that, the specification of uv was also corrected.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5977

# Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Reversed the order of specifying the 2nd and 3rd vertices, and slightly modified the uv.

# Screenshots of the change:
```js
function setup(){
  createCanvas(400, 400, WEBGL);
  directionalLight(255, 255, 255, 0, 0, -1);
  ambientLight(64);
  ambientMaterial(255);
  fill(255, 128, 0);
  triangle(0, 0, 200, 0, 200, 200);
}
```
before / after
<!-- If applicable, add screenshots depicting the changes. -->
![tri3](https://user-images.githubusercontent.com/39549290/214994532-deab4b37-d31b-410f-babd-2c0af7de2ce6.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
